### PR TITLE
systemd: include incus.sysusers

### DIFF
--- a/systemd/incus.sysusers
+++ b/systemd/incus.sysusers
@@ -1,0 +1,4 @@
+g incus - -
+g incus-admin - -
+u incus - "Incus user" /var/lib/incus /usr/bin/nologin
+m incus incus


### PR DESCRIPTION
This file enables the creation of all incus groups and users during
package installation without the need for programatic post install
scripts.

Signed-off-by: Morten Linderud <morten@linderud.pw>
