### PR TITLE
Usage wget in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Packages provided by the repository are signed. In order to verify the integrity
 curl -fsSL https://pkgs.zabbly.com/key.asc | gpg --show-keys --fingerprint
 ```
 
+or if your system has wget instead of curl use
+
+```sh
+wget -q -O - https://pkgs.zabbly.com/key.asc | gpg --show-keys --fingerprint
+```
+
+You should get a return that is:
+
 ```sh
 pub   rsa3072 2023-08-23 [SC] [expires: 2025-08-22]
       4EFC 5906 96CB 15B8 7C73  A3AD 82CC 8797 C838 DCFD

--- a/README.md
+++ b/README.md
@@ -49,12 +49,24 @@ uid                      Zabbly Kernel Builds <info@zabbly.com>
 sub   rsa3072 2023-08-23 [E] [expires: 2025-08-22]
 ```
 
-If so, save the key locally:
+If so, make sure the directory /etc/apt/keyrings exists:
 
 ```sh
 mkdir -p /etc/apt/keyrings/
+```
+
+and save the key locally with either curl:
+
+```sh
 curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
 ```
+
+or wget
+
+```sh
+wget -O /etc/apt/keyrings/zabbly.asc https://pkgs.zabbly.com/key.asc
+```
+
 
 ### 6.0 LTS repository
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and save the key locally with either curl:
 curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
 ```
 
-or wget
+or wget:
 
 ```sh
 wget -O /etc/apt/keyrings/zabbly.asc https://pkgs.zabbly.com/key.asc


### PR DESCRIPTION
The default install for Debian 12 does not include curl, but does include wget. 

Adding documentation for wget as an alternative for curl thus makes sense. 