### PR TITLE
incus-ui-canonical: rebrand html files

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -363,7 +363,7 @@ jobs:
           cd /build/incus-ui-canonical
 
           # Complete re-branding.
-          find -type f -name "*.ts" -o -name "*.tsx" -o -name "*.scss" | xargs sed -i -f "${REPO}/patches/ui-canonical-renames.sed"
+          find -type f -name "*.ts" -o -name "*.tsx" -o -name "*.scss" -o -name "*.html" | xargs sed -i -f "${REPO}/patches/ui-canonical-renames.sed"
 
           npm install yarn --global
           yarn install


### PR DESCRIPTION
Our nixos tests were checking the rebrand of the home page and failed.

Looks like html files are being missed in 0.15

https://github.com/canonical/lxd-ui/blob/3fd8cb217fee37a8ea9b7866b2a1ac0e78fa9681/index.html#L8