### PR TITLE
avoid incus nat rule being flushed by nftables at startup

### DIFF
--- a/systemd/incus.service
+++ b/systemd/incus.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Incus - Daemon
-After=network-online.target openvswitch-switch.service incus-lxcfs.service incus.socket
+After=network-online.target openvswitch-switch.service incus-lxcfs.service incus.socket nftables.service
 Requires=network-online.target incus-lxcfs.service incus.socket
 
 [Service]


### PR DESCRIPTION
I handle incus firewall manually (along with other rules)with nftables,but incus nat rules are still flushed by nftables service on boot.