### PR TITLE
do not build unwanted test binary for qemu

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -561,6 +561,8 @@ jobs:
           patch -p1 < "${REPO}/patches/qemu-0001-usb-net-mac.patch"
 
           sed -i "s/^unset target_list$/target_list=\"$(uname -m)-softmmu\"/" configure
+
+          sed -i "/subdir('tests')/d" meson.build
           ./configure \
                   --prefix=/opt/incus \
                   --libexecdir=bin \


### PR DESCRIPTION
Qemu test binaries are built unconditionaly, even if we are not gonna run or need it.

Remove this dep from meson build file. Which speedup the workflow a lot.