### PR TITLE
de-install incus-migrate if installing the incus-extra package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -115,8 +115,8 @@ Description: Incus - Command line client
 Package: incus-extra
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Breaks: incus (<< ${source:Version}), distrobuilder
-Replaces: incus (<< ${source:Version}), distrobuilder
+Breaks: incus (<< ${source:Version}), distrobuilder, incus-migrate
+Replaces: incus (<< ${source:Version}), distrobuilder, incus-migrate
 Recommends:
   debootstrap,
   gdisk,


### PR DESCRIPTION
Add the conflicting package to the 'Breaks' and 'Replaces' clauses, so it will be de-installed if the package 'incus-extra' gets installed.

Signed-off-by: Toni Müller <support@oeko.net>