### PR TITLE
lxcfs: always create /var/lib/incus-lxcfs

### DIFF
--- a/debian/incus-base.dirs
+++ b/debian/incus-base.dirs
@@ -1,0 +1,1 @@
+/var/lib/incus-lxcfs


### PR DESCRIPTION
systemd unit for lxcfs has the following line:
```
ExecStartPre=/bin/mkdir -p {{LXCFSTARGETDIR}}
```
which should create /var/lib/incus-lxcfs for us, but the problem is that we also have condition:
```
ConditionVirtualization=!container
```
When incus-base is installed inside a container,
then LXCFS never starts inside and /var/lib/incus-lxcfs is not getting created.

And this alone is fine, because we expect lxc.mount.hook to bind mount lxcfs from the host for us (no need to run lxcfs daemons inside containers), but lxc.mount.hook has the following checks:
```
if [ -d "${LXC_ROOTFS_MOUNT}/var/lib/incus-lxcfs/" ]; then
    rm -Rf "${LXC_ROOTFS_MOUNT}/var/lib/incus-lxcfs"
    mkdir -p "${LXC_ROOTFS_MOUNT}/var/lib/incus-lxcfs"
    mount -n --bind /var/lib/incus-lxcfs "${LXC_ROOTFS_MOUNT}/var/lib/incus-lxcfs/"
fi

if [ -d "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/" ]; then
    rm -Rf "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs"
    mkdir -p "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs"
    mount -n --bind /var/lib/incus-lxcfs "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/"
fi
```
I.e. bindmounting happens only if /var/lib/lxcfs or /var/lib/incus-lxcfs exist. In our case, it never exists with Zabbly Incus. This problem is not reproducible with Incus package from Debian, because they have: https://salsa.debian.org/lxc-team/lxcfs/-/blob/debian/sid/debian/lxcfs.dirs?ref_type=heads

Let's also add this debian rule to create LXCFS mountpoint directory, when incus-base is installed.