### PR TITLE
Use libgpgme45 for Ubuntu 26.04.

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -723,7 +723,6 @@ jobs:
               -e "s/LIBUSBREDIRPARSER1/libusbredirparser1t64/g" \
               -e "s/LIBAIO1/libaio1t64/g" \
               -e "s/LIBBTRFS0/libbtrfs0t64/g" \
-              -e "s/LIBGPGME11/libgpgme11t64/g" \
               -e "s/LIBUV1/libuv1t64/g"
           else
             sed -i debian/control \
@@ -731,7 +730,6 @@ jobs:
               -e "s/LIBUSBREDIRPARSER1/libusbredirparser1/g" \
               -e "s/LIBAIO1/libaio1/g" \
               -e "s/LIBBTRFS0/libbtrfs0/g" \
-              -e "s/LIBGPGME11/libgpgme11/g" \
               -e "s/LIBUV1/libuv1/g"
           fi
 
@@ -741,6 +739,17 @@ jobs:
           else
             sed -i debian/control \
               -e "s/LIBFUSE3/libfuse3-3/g"
+          fi
+
+          if [ "${PKGOS}" = "ubuntu-26.04" ]; then
+            sed -i debian/control \
+              -e "s/LIBGPGME11/libgpgme45/g"
+          elif [ "${PKGOS}" = "debian-13" ] || [ "${PKGOS}" = "ubuntu-24.04" ]; then
+            sed -i debian/control \
+              -e "s/LIBGPGME11/libgpgme11t64/g"
+          else
+            sed -i debian/control \
+              -e "s/LIBGPGME11/libgpgme11/g"
           fi
 
           dch --package incus --create -D ${CODENAME} -M -m "Automated Incus daily build" -v 1:0~$(echo ${PKGOS} | sed "s/-//g")~$(date -u +%Y%m%d%H%M) --force-distribution


### PR DESCRIPTION
Ubuntu 26.04 uses a newer version of libgpgme. I hope this is the last different runtime library. :)
