### PR TITLE
debian/postinst: Only restart incus if unit is not masked and active.

### DIFF
--- a/debian/incus-base.postinst
+++ b/debian/incus-base.postinst
@@ -78,7 +78,8 @@ if [ "$1" = "configure" ]; then
         done
 
         # Restart or reload anything that's currently running.
-        if systemctl is-active incus.service -q; then
+        INCUS_SERVICE_STATE="$(systemctl is-enabled incus.service 2>/dev/null || true)"
+        if [ "${INCUS_SERVICE_STATE}" != "masked" ] && systemctl is-active incus.service -q; then
             systemctl restart incus.service
         fi
 


### PR DESCRIPTION
As per you suggestion in https://github.com/lxc/incus/issues/3599, we could utilize unit masking to perform incus cluster upgrades with minimal downtime.
While playing around with that idea, I noticed that the postinst always issues a restart of incus, which under normal circumstances makes perfect sense. When the unit is masked however, a `systemctl restart incus.service` return wiht a non-zero exit code. This then causes apt to consider the upgrade as failed.

This PR introduces a simple check if the `incus` unit is masked, if so the restart is skipped and must be manually triggered by the user.